### PR TITLE
fix: Workbox does not allow `CacheFirst` strategy for opaque responses

### DIFF
--- a/src/custom-sw-code.js
+++ b/src/custom-sw-code.js
@@ -2,6 +2,6 @@
 // Cache SVG's loaded from Firebase storage bucket and not served via Gatsby itself
 workbox.routing.registerRoute(
   /^https:\/\/storage\.googleapis\.com\/flamelink-website\.appspot\.com\/.*\.svg/,
-  new workbox.strategies.CacheFirst()
+  new workbox.strategies.StaleWhileRevalidate()
 )
 /* eslint-enable no-undef */


### PR DESCRIPTION
Trying to use `StaleWhileRevalidate` instead.